### PR TITLE
resolve linting warnings

### DIFF
--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -1,5 +1,13 @@
-- name: Make sure python is present (installs v2)
+---
+- name: Check for Python
+  raw: test -e /usr/bin/python
+  changed_when: false
+  failed_when: false
+  register: python
+
+- name: Install Python
   raw: "test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)"
+  when: python.rc != 0
 
 - name: Gather Facts, now that we have python
   setup:

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -6,7 +6,7 @@
   register: python
 
 - name: Install Python
-  raw: "test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)"
+  raw: "apt -y update && apt install -y python-minimal"
   when: python.rc != 0
 
 - name: Gather Facts, now that we have python

--- a/roles/dockerdrop/tasks/docker_ce.yml
+++ b/roles/dockerdrop/tasks/docker_ce.yml
@@ -1,3 +1,4 @@
+---
 - name: Install requirements for docker CE repo.
   apt:
     pkg:

--- a/roles/dockerdrop/tasks/main.yml
+++ b/roles/dockerdrop/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Remove old docker
   import_tasks: purge-old.yml
 

--- a/roles/dockerdrop/tasks/purge-old.yml
+++ b/roles/dockerdrop/tasks/purge-old.yml
@@ -1,3 +1,4 @@
+---
 - name: Purge distro docker
   apt:
     state: absent

--- a/roles/jitsi/files/jitsi.service
+++ b/roles/jitsi/files/jitsi.service
@@ -1,6 +1,9 @@
+# {{ ansible_managed }}
+
 [Unit]
 Requires=docker.service
 After=docker.service
+
 [Service]
 Type=simple
 WorkingDirectory=/opt/jitsi-meet
@@ -8,5 +11,6 @@ ExecStart=/usr/bin/docker-compose up
 ExecStop=/usr/bin/docker-compose down
 Restart=always
 RestartSec=5
+
 [Install]
 WantedBy=multi-user.target

--- a/roles/jitsi/handlers/main.yml
+++ b/roles/jitsi/handlers/main.yml
@@ -1,7 +1,6 @@
-- name: Reload unit files
-  shell: systemctl daemon-reload
-
+---
 - name: Restart jitsi
-  service:
+  systemd:
     name: jitsi
     state: restarted
+    daemon_reload: true

--- a/roles/jitsi/tasks/main.yml
+++ b/roles/jitsi/tasks/main.yml
@@ -9,6 +9,7 @@
     repo: https://github.com/jitsi/docker-jitsi-meet.git
     dest: /opt/jitsi-meet
     accept_hostkey: yes
+    version: master
   notify: Restart jitsi
 
 - name: Put unit file for jitsi

--- a/roles/jitsi/tasks/main.yml
+++ b/roles/jitsi/tasks/main.yml
@@ -18,7 +18,6 @@
     src: jitsi.service
     dest: /etc/systemd/system/jitsi.service
   notify:
-    - Reload unit files
     - Restart jitsi
 
 - name: Put jitsi config file from default, if it doesn't exist

--- a/roles/jitsi/tasks/main.yml
+++ b/roles/jitsi/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Ensure docker-compose and git are installed
   apt:
     pkg:


### PR DESCRIPTION
```bash
[301] Commands should not change things if nothing needs doing
roles/bootstrap/tasks/main.yml:1
Task/Handler: Make sure python is present (installs v2)

[303] systemctl used in place of systemd module
roles/jitsi/handlers/main.yml:1
Task/Handler: Reload unit files

[305] Use shell only when shell functionality is required
roles/jitsi/handlers/main.yml:1
Task/Handler: Reload unit files

[401] Git checkouts must contain explicit version
roles/jitsi/tasks/main.yml:7
Task/Handler: Get jitsi docker compose setup
```
*(and change layout of all yaml files)*